### PR TITLE
update build runtime

### DIFF
--- a/runtime/php/compiler.Dockerfile
+++ b/runtime/php/compiler.Dockerfile
@@ -8,7 +8,7 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
 # AWS has kindly provided us with it as a base docker image.
 # https://github.com/aws/amazon-linux-docker-images/tree/2017.03
-FROM amazonlinux:2017.03
+FROM amazonlinux:2018.03
 LABEL authors="Bubba Hines <bubba@stechstudio.com>"
 LABEL vendor1="Signature Tech Studio, Inc."
 LABEL vendor2="bref"

--- a/runtime/php/versions.ini
+++ b/runtime/php/versions.ini
@@ -56,7 +56,9 @@ postgres = "9.6.11"
 ;   - php
 libzip = "1.5.1"
 
-php = "7.3.2"
+icu4c = "62.1"
+
+php = "7.3.6"
 
 [php72]
 ; https://github.com/madler/zlib/releases
@@ -116,4 +118,6 @@ postgres = "9.6.11"
 ;   - php
 libzip = "1.5.1"
 
-php = "7.2.15"
+icu4c = "62.1"
+
+php = "7.2.19"


### PR DESCRIPTION
Our build issue is with the [Internationalization extension](https://www.php.net/manual/en/book.intl.php). Particularly the [icu4c](http://site.icu-project.org/home) version that the intl extension builds against. 

There have been [a handful of noteworthy bugs](https://www.google.com/search?q=php+bug+icu4c&oq=php+bug+icu4c&aqs=chrome..69i57j69i64l3.7271j0j4&sourceid=chrome&ie=UTF-8) in the **intl** extension with finickiness around the **icu4c** version. We attempted building against a handful of versions, but have yet to nail it down.

However, to demonstrate that this is indeed the root cause, I removed `--enable-intl=shared` from the `./configure` arguments and had no problems building the system. We just need to find that sweet spot of **AmazonLinux + PHP + INTL + ICU** versions to make it work. 